### PR TITLE
Upgrade to latest schemacrawler 14.x : 14.21.02

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ License along with this program.  If not, see
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<schemacrawler.version>14.20.02</schemacrawler.version>
+		<schemacrawler.version>14.21.02</schemacrawler.version>
 		<java.version>1.8</java.version>
 		<java.version.short>8</java.version.short>
 		<hsqldb.version>2.3.2</hsqldb.version>


### PR DESCRIPTION
Upgrade to the latest schemacrawler does not break all sqlType mappings see https://github.com/schemacrawler/SchemaCrawler/issues/167