### PR TITLE
BLOB Compression lint, requesting, target dir expected  correction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ License along with this program.  If not, see
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.mbarre</groupId>
 	<artifactId>schemacrawler-additional-lints</artifactId>
-	<version>1.04.03-SNAPSHOT</version>
+	<version>1.04.04</version>
 	<name>Additional SchemaCrawler Lints</name>
 	<description>Some additional lints for Schemacrawler</description>
 	<inceptionYear>2015</inceptionYear>


### PR DESCRIPTION
Create temps files (and delete them after processing) for blob compression inspection instead of persisted files in a potential non-exiting target directory