### PR TITLE
Timestamp_without_Timezone lint

### DIFF
--- a/src/main/java/io/github/mbarre/schemacrawler/tool/linter/LinterTimeStampWithOutTimeZoneColumn.java
+++ b/src/main/java/io/github/mbarre/schemacrawler/tool/linter/LinterTimeStampWithOutTimeZoneColumn.java
@@ -1,0 +1,95 @@
+package io.github.mbarre.schemacrawler.tool.linter;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.github.mbarre.schemacrawler.utils.LintUtils;
+
+/*
+ * #%L
+ * Additional SchemaCrawler Lints
+ * %%
+ * Copyright (C) 2015 - 2016 github
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+import schemacrawler.schema.Column;
+import schemacrawler.schema.Table;
+import schemacrawler.tools.lint.BaseLinter;
+import schemacrawler.tools.lint.LintSeverity;
+
+/**
+ * Linter to check if the column has any TimeStamp data type columns if so suggest to use TimeStamp with TimeZones - PostgreSQL reserved
+ * lint
+ * 
+ * @author Bheem
+ * @since 1.0.0
+ */
+public class LinterTimeStampWithOutTimeZoneColumn extends BaseLinter {
+	private static final Logger LOGGER = Logger.getLogger(LinterTimeStampWithOutTimeZoneColumn.class.getName());
+
+	/**
+	 * The lint that test if column with TimeStamp data type alone used without TimeZone
+	 *
+	 */
+	public LinterTimeStampWithOutTimeZoneColumn() {
+		super();
+        setSeverity(LintSeverity.critical);
+	}
+
+	/**
+	 * Get the description
+	 * 
+	 * @return the description
+	 */
+	
+	public String getDescription() {
+		return "Timestamp without time zone (timestamp) is not a permitted data type. Use timestamp with time zone (timestamptz)";
+	}
+
+	/**
+	 * Get the summary
+	 * 
+	 * @return the summary
+	 */
+	@Override
+	public String getSummary() {
+		return "Use timeStamptz instead of just TimeStamp";
+	}
+
+	/**
+	 * The lint that does the job
+	 * 
+	 * @param table
+	 *            table
+	 * @param connection
+	 *            connection
+	 */
+	@Override
+	protected void lint(final Table table, final Connection connection) {
+		List<Column> columns = getColumns(table);
+		for (Column column : columns) {
+			LOGGER.log(Level.INFO, "Checking {0}...", column.getFullName());
+			if (LintUtils.isSqlTypeTimeStampBased(column.getColumnDataType().getJavaSqlType().getVendorTypeNumber())) {
+				addLint(table, getDescription(), column.getFullName());
+			}
+		}
+	}
+
+}

--- a/src/main/java/io/github/mbarre/schemacrawler/utils/LintUtils.java
+++ b/src/main/java/io/github/mbarre/schemacrawler/utils/LintUtils.java
@@ -124,6 +124,16 @@ public class LintUtils {
 				|| javaSqlType == Types.TIMESTAMP
 				|| javaSqlType == Types.TIMESTAMP_WITH_TIMEZONE;
 	}
+	
+	/**
+	 * Tells whether a column is TimeStamp like type or not.
+	 * @param javaSqlType the dataType
+	 * @return is the sqlType is TimeStamp based or not
+	 */
+	public static final boolean isSqlTypeTimeStampBased(int javaSqlType) {
+		return javaSqlType == Types.TIMESTAMP;
+	}
+	
 
 	public static Set<Long> generateSample(int sampleSize, Long totalRows){
 		Set<Long> sampleIndex = new HashSet<>();

--- a/src/main/resources/META-INF/services/schemacrawler.tools.lint.Linter
+++ b/src/main/resources/META-INF/services/schemacrawler.tools.lint.Linter
@@ -17,3 +17,4 @@ io.github.mbarre.schemacrawler.tool.linter.LinterNoSpaceInNames
 io.github.mbarre.schemacrawler.tool.linter.LinterPluralTableName
 io.github.mbarre.schemacrawler.tool.linter.LinterLeftSpacePadding
 io.github.mbarre.schemacrawler.tool.linter.LinterRightSpacePadding
+io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn

--- a/src/main/resources/schemacrawler-linter-config.xml
+++ b/src/main/resources/schemacrawler-linter-config.xml
@@ -204,6 +204,7 @@
     </linter>
     <linter id="io.github.mbarre.schemacrawler.tool.linter.LinterOrphanTable">
         <run>true</run>
+        <severity>high</severity>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
     <linter id="io.github.mbarre.schemacrawler.tool.linter.LinterForbiddenPrimaryKeyType">
@@ -219,6 +220,12 @@
 	<linter id="io.github.mbarre.schemacrawler.tool.linter.LinterLeftSpacePadding">
 		<run>true</run>
 		<severity>high</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>true</run>
+		<severity>critical</severity>
 		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
 	</linter>
 

--- a/src/test/db/liquibase/LinterTimeStampWithOutTimeZoneColumn/db.changelog.xml
+++ b/src/test/db/liquibase/LinterTimeStampWithOutTimeZoneColumn/db.changelog.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  #%L
+  Additional SchemaCrawler Lints
+  %%
+  Copyright (C) 2015 - 2016 github
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  You should have received a copy of the GNU General Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/gpl-3.0.html>.
+  #L%
+  -->
+
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+	<changeSet author="bheem" id="1516923589828-1" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+
+		<createTable  tableName="test_timetsamp_type" remarks="table for lint LinterTimeStampWithOutTimeZoneColumn">
+			<column name="id" 				type="int" 			remarks="primary key"/>
+			<column name="content"                          type="varchar(20)"/>
+			<column name="created_at"                          type="timestamp" remarks="column timestamp type"/>
+		</createTable>
+
+		<addPrimaryKey columnNames="id"
+					   constraintName="pk_timetsamp_test"
+					   schemaName="public"
+					   tableName="test_timetsamp_type"/>
+
+		<sql>insert into test_timetsamp_type(id, content, created_at) values (1, 'timestamp_lint', current_timestamp)</sql>
+
+	</changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/TestLintPlugin.java
+++ b/src/test/java/TestLintPlugin.java
@@ -45,6 +45,7 @@ public class TestLintPlugin
     assertTrue(registry.hasLinter("io.github.mbarre.schemacrawler.tool.linter.LinterPluralTableName"));
     assertTrue(registry.hasLinter("io.github.mbarre.schemacrawler.tool.linter.LinterLeftSpacePadding"));
     assertTrue(registry.hasLinter("io.github.mbarre.schemacrawler.tool.linter.LinterRightSpacePadding"));
+    assertTrue(registry.hasLinter("io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn"));
   }
 
 }

--- a/src/test/java/io/github/mbarre/schemacrawler/tool/linter/LinterTimeStampWithOutTimeZoneColumnTest.java
+++ b/src/test/java/io/github/mbarre/schemacrawler/tool/linter/LinterTimeStampWithOutTimeZoneColumnTest.java
@@ -1,0 +1,72 @@
+package io.github.mbarre.schemacrawler.tool.linter;
+
+/*-
+ * #%L
+ * Additional SchemaCrawler Lints
+ * %%
+ * Copyright (C) 2015 - 2019 github
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.github.mbarre.schemacrawler.test.utils.LintWrapper;
+import io.github.mbarre.schemacrawler.test.utils.PostgreSqlDatabase;
+import schemacrawler.schemacrawler.SchemaCrawlerOptions;
+import schemacrawler.schemacrawler.SchemaCrawlerOptionsBuilder;
+import schemacrawler.schemacrawler.SchemaInfoLevelBuilder;
+import schemacrawler.tools.lint.LinterRegistry;
+
+public class LinterTimeStampWithOutTimeZoneColumnTest extends BaseLintTest {
+	
+	private static final String CHANGE_LOG_TIMESTAMP_CHECK = "src/test/db/liquibase/LinterTimeStampWithOutTimeZoneColumn/db.changelog.xml";
+	private static PostgreSqlDatabase database;
+
+	@BeforeClass
+	public static void  init(){
+		database = new PostgreSqlDatabase();
+		database.setUp(CHANGE_LOG_TIMESTAMP_CHECK);
+	}
+
+	@Test
+	public void testLint() throws Exception{
+
+		final LinterRegistry registry = new LinterRegistry();
+		Assert.assertTrue(registry.hasLinter(LinterTimeStampWithOutTimeZoneColumn.class.getName()));
+
+		final SchemaCrawlerOptions options = SchemaCrawlerOptionsBuilder.builder().withSchemaInfoLevel(SchemaInfoLevelBuilder.standard()).toOptions();
+
+		Connection connection = DriverManager.getConnection(PostgreSqlDatabase.CONNECTION_STRING,
+				PostgreSqlDatabase.USER_NAME, database.getPostgresPassword());
+
+		List<LintWrapper> lints = executeToJsonAndConvertToLintList(LinterTimeStampWithOutTimeZoneColumn.class.getSimpleName(), options, connection);
+		Assert.assertEquals(1,lints.size());
+		int index = 0;
+		Assert.assertEquals(LinterTimeStampWithOutTimeZoneColumn.class.getName(), lints.get(index).getId());
+		Assert.assertEquals("public.test_timetsamp_type.created_at", lints.get(index).getValue());
+		Assert.assertEquals("Timestamp without time zone (timestamp) is not a permitted data type. Use timestamp with time zone (timestamptz)", lints.get(index).getDescription());
+		Assert.assertEquals("critical", lints.get(index).getSeverity());
+
+	}
+
+}

--- a/src/test/java/io/github/mbarre/schemacrawler/utils/LintUtilsTest.java
+++ b/src/test/java/io/github/mbarre/schemacrawler/utils/LintUtilsTest.java
@@ -1,5 +1,7 @@
 package io.github.mbarre.schemacrawler.utils;
 
+import java.sql.Types;
+
 /*
  * #%L
  * Additional SchemaCrawler Lints
@@ -25,235 +27,277 @@ package io.github.mbarre.schemacrawler.utils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.reflect.Type;
-import java.sql.Types;
-
 /**
  *
  * @author salad74
  */
 public class LintUtilsTest {
-    
-    public LintUtilsTest() {
-        Assert.assertTrue(true);
-    }
-    
+
+	public LintUtilsTest() {
+		Assert.assertTrue(true);
+	}
+
+	/**
+	 * Test of isSqlTypeTextBased method, of class LintUtils.
+	 */
+	@Test
+	public void testIsSqlTypeTextBased() {
+		Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.NVARCHAR));
+		Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.LONGNVARCHAR));
+		Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.LONGVARCHAR));
+		Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.CHAR));
+		Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.NCHAR));
+		Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.VARCHAR));
+
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.BIGINT));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.BINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.BIT));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.ARRAY));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.BLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.BOOLEAN));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.CLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.DATALINK));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.DATE));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.DECIMAL));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.DISTINCT));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.DOUBLE));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.FLOAT));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.INTEGER));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.JAVA_OBJECT));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.LONGVARBINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.NCLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.NULL));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.NUMERIC));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.OTHER));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.REAL));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.SMALLINT));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.SQLXML));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.TIME));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.TIMESTAMP));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.TIMESTAMP_WITH_TIMEZONE));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.TINYINT));
+		Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.VARBINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.TIME));
+	}
+
+	/**
+	 * Test of testIsSqlTypeNumericBased method, of class LintUtils.
+	 */
+	@Test
+	public void testIsSqlTypeNumericBased() {
+
+		Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.BIGINT));
+		Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.DECIMAL));
+		Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.NUMERIC));
+		Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.REAL));
+		Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.SMALLINT));
+		Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.TINYINT));
+		Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.DOUBLE));
+		Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.FLOAT));
+		Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.INTEGER));
+
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.NVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.LONGNVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.LONGVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.CHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.NCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.VARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.BINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.BIT));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.ARRAY));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.BLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.BOOLEAN));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.CLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.DATALINK));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.DATE));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.DISTINCT));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.JAVA_OBJECT));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.LONGVARBINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.NCLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.NULL));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.OTHER));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.SQLXML));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.TIME));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.TIMESTAMP));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.TIMESTAMP_WITH_TIMEZONE));
+		Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.VARBINARY));
+	}
+
+	/**
+	 * Test of testIsSqlTypeNumericBased method, of class LintUtils.
+	 */
+	@Test
+	public void testIsSqlTypeIntegerBased() {
+
+		Assert.assertTrue(LintUtils.isSqlTypeIntegerBased(Types.BIGINT));
+		Assert.assertTrue(LintUtils.isSqlTypeIntegerBased(Types.INTEGER));
+		Assert.assertTrue(LintUtils.isSqlTypeIntegerBased(Types.SMALLINT));
+		Assert.assertTrue(LintUtils.isSqlTypeIntegerBased(Types.TINYINT));
+
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.BINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.NVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.LONGNVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.LONGVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.CHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.NCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.VARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.BIT));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.ARRAY));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.BLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.BOOLEAN));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.CLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.DATALINK));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.DATE));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.DECIMAL));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.DISTINCT));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.DOUBLE));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.FLOAT));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.JAVA_OBJECT));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.LONGVARBINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.NCLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.NULL));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.NUMERIC));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.OTHER));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.REAL));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.SQLXML));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.TIME));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.TIMESTAMP));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.TIMESTAMP_WITH_TIMEZONE));
+		Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.VARBINARY));
+	}
+
+	/**
+	 * Test of testIsSqlTypeNumericBased method, of class LintUtils.
+	 */
+	@Test
+	public void testIsSqlTypeBinaryBased() {
+
+		Assert.assertTrue(LintUtils.isSqlTypeBinayBased(Types.BINARY));
+		Assert.assertTrue(LintUtils.isSqlTypeBinayBased(Types.BLOB));
+		Assert.assertTrue(LintUtils.isSqlTypeBinayBased(Types.LONGVARBINARY));
+		Assert.assertTrue(LintUtils.isSqlTypeBinayBased(Types.VARBINARY));
+
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.BIGINT));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.DECIMAL));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.NUMERIC));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.REAL));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.SMALLINT));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.TINYINT));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.DOUBLE));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.FLOAT));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.INTEGER));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.NVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.LONGNVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.LONGVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.CHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.NCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.VARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.BIT));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.ARRAY));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.BOOLEAN));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.CLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.DATALINK));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.DATE));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.DISTINCT));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.JAVA_OBJECT));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.NCLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.NULL));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.OTHER));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.SQLXML));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.TIME));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.TIMESTAMP));
+		Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.TIMESTAMP_WITH_TIMEZONE));
+
+	}
+
+	/**
+	 * Test of testIsSqlTypeNumericBased method, of class LintUtils.
+	 */
+	@Test
+	public void testIsSqlTypeDateBased() {
+		Assert.assertTrue(LintUtils.isSqlTypeDateBased(Types.DATE));
+		Assert.assertTrue(LintUtils.isSqlTypeDateBased(Types.TIME));
+		Assert.assertTrue(LintUtils.isSqlTypeDateBased(Types.TIME_WITH_TIMEZONE));
+		Assert.assertTrue(LintUtils.isSqlTypeDateBased(Types.TIMESTAMP));
+		Assert.assertTrue(LintUtils.isSqlTypeDateBased(Types.TIMESTAMP_WITH_TIMEZONE));
+
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.BINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.BLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.LONGVARBINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.VARBINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.BIGINT));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.DECIMAL));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.NUMERIC));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.REAL));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.SMALLINT));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.TINYINT));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.DOUBLE));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.FLOAT));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.INTEGER));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.NVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.LONGNVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.LONGVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.CHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.NCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.VARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.BIT));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.ARRAY));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.BOOLEAN));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.CLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.DATALINK));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.DISTINCT));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.JAVA_OBJECT));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.NCLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.NULL));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.OTHER));
+		Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.SQLXML));
+	}
+
+	/**
+	 * Test of testIsSqlTypeTimeStampBased method, of class LintUtils.
+	 */
+	@Test
+	public void testIsSqlTypeTimeStampBased() {
+		Assert.assertTrue(LintUtils.isSqlTypeTimeStampBased(Types.TIMESTAMP));
+
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.BINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.BLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.LONGVARBINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.VARBINARY));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.BIGINT));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.DECIMAL));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.NUMERIC));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.REAL));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.SMALLINT));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.TINYINT));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.DOUBLE));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.FLOAT));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.INTEGER));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.NVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.LONGNVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.LONGVARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.CHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.NCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.VARCHAR));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.BIT));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.ARRAY));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.BOOLEAN));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.CLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.DATALINK));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.DISTINCT));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.JAVA_OBJECT));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.NCLOB));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.NULL));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.OTHER));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.SQLXML));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.DATE));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.TIME));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.TIME_WITH_TIMEZONE));
+		Assert.assertFalse(LintUtils.isSqlTypeTimeStampBased(Types.TIMESTAMP_WITH_TIMEZONE));
 
 
-    /**
-     * Test of isSqlTypeTextBased method, of class LintUtils.
-     */
-    @Test
-    public void testIsSqlTypeTextBased() {
-        Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.NVARCHAR));
-        Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.LONGNVARCHAR));
-        Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.LONGVARCHAR));
-        Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.CHAR));
-        Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.NCHAR));
-        Assert.assertTrue(LintUtils.isSqlTypeTextBased(Types.VARCHAR));
 
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.BIGINT));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.BINARY));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.BIT));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.ARRAY));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.BLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.BOOLEAN));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.CLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.DATALINK));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.DATE));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.DECIMAL));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.DISTINCT));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.DOUBLE));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.FLOAT));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.INTEGER));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.JAVA_OBJECT));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.LONGVARBINARY));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.NCLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.NULL));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.NUMERIC));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.OTHER));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.REAL));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.SMALLINT));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.SQLXML));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.TIME));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.TIMESTAMP));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.TIMESTAMP_WITH_TIMEZONE));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.TINYINT));
-        Assert.assertFalse(LintUtils.isSqlTypeTextBased(Types.VARBINARY));
-    }
-    
-    
-    /**
-     * Test of testIsSqlTypeNumericBased method, of class LintUtils.
-     */
-    @Test
-    public void testIsSqlTypeNumericBased() {
-        
-        Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.BIGINT));
-        Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.DECIMAL));
-        Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.NUMERIC));
-        Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.REAL));
-        Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.SMALLINT));
-        Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.TINYINT));
-        Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.DOUBLE));
-        Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.FLOAT));
-        Assert.assertTrue(LintUtils.isSqlTypeNumericBased(Types.INTEGER));
-        
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.NVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.LONGNVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.LONGVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.CHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.NCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.VARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.BINARY));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.BIT));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.ARRAY));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.BLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.BOOLEAN));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.CLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.DATALINK));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.DATE));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.DISTINCT));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.JAVA_OBJECT));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.LONGVARBINARY));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.NCLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.NULL));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.OTHER));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.SQLXML));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.TIME));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.TIMESTAMP));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.TIMESTAMP_WITH_TIMEZONE));
-        Assert.assertFalse(LintUtils.isSqlTypeNumericBased(Types.VARBINARY));
-    }
-    
-     /**
-     * Test of testIsSqlTypeNumericBased method, of class LintUtils.
-     */
-    @Test
-    public void testIsSqlTypeIntegerBased() {
-        
-        Assert.assertTrue(LintUtils.isSqlTypeIntegerBased(Types.BIGINT));
-        Assert.assertTrue(LintUtils.isSqlTypeIntegerBased(Types.INTEGER));
-        Assert.assertTrue(LintUtils.isSqlTypeIntegerBased(Types.SMALLINT));
-        Assert.assertTrue(LintUtils.isSqlTypeIntegerBased(Types.TINYINT));
 
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.BINARY));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.NVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.LONGNVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.LONGVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.CHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.NCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.VARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.BIT));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.ARRAY));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.BLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.BOOLEAN));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.CLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.DATALINK));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.DATE));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.DECIMAL));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.DISTINCT));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.DOUBLE));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.FLOAT));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.JAVA_OBJECT));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.LONGVARBINARY));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.NCLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.NULL));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.NUMERIC));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.OTHER));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.REAL));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.SQLXML));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.TIME));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.TIMESTAMP));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.TIMESTAMP_WITH_TIMEZONE));
-        Assert.assertFalse(LintUtils.isSqlTypeIntegerBased(Types.VARBINARY));
-    }
-    
-     /**
-     * Test of testIsSqlTypeNumericBased method, of class LintUtils.
-     */
-    @Test
-    public void testIsSqlTypeBinaryBased() {
-        
-        Assert.assertTrue(LintUtils.isSqlTypeBinayBased(Types.BINARY));
-        Assert.assertTrue(LintUtils.isSqlTypeBinayBased(Types.BLOB));
-        Assert.assertTrue(LintUtils.isSqlTypeBinayBased(Types.LONGVARBINARY));
-        Assert.assertTrue(LintUtils.isSqlTypeBinayBased(Types.VARBINARY));
-        
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.BIGINT));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.DECIMAL));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.NUMERIC));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.REAL));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.SMALLINT));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.TINYINT));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.DOUBLE));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.FLOAT));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.INTEGER));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.NVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.LONGNVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.LONGVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.CHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.NCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.VARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.BIT));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.ARRAY));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.BOOLEAN));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.CLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.DATALINK));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.DATE));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.DISTINCT));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.JAVA_OBJECT));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.NCLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.NULL));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.OTHER));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.SQLXML));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.TIME));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.TIMESTAMP));
-        Assert.assertFalse(LintUtils.isSqlTypeBinayBased(Types.TIMESTAMP_WITH_TIMEZONE));
-        
-    }
+	}
 
-    /**
-     * Test of testIsSqlTypeNumericBased method, of class LintUtils.
-     */
-    @Test
-    public void testIsSqlTypeDateBased() {
-        Assert.assertTrue(LintUtils.isSqlTypeDateBased(Types.DATE));
-        Assert.assertTrue(LintUtils.isSqlTypeDateBased(Types.TIME));
-        Assert.assertTrue(LintUtils.isSqlTypeDateBased(Types.TIME_WITH_TIMEZONE));
-        Assert.assertTrue(LintUtils.isSqlTypeDateBased(Types.TIMESTAMP));
-        Assert.assertTrue(LintUtils.isSqlTypeDateBased(Types.TIMESTAMP_WITH_TIMEZONE));
-
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.BINARY));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.BLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.LONGVARBINARY));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.VARBINARY));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.BIGINT));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.DECIMAL));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.NUMERIC));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.REAL));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.SMALLINT));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.TINYINT));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.DOUBLE));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.FLOAT));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.INTEGER));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.NVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.LONGNVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.LONGVARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.CHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.NCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.VARCHAR));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.BIT));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.ARRAY));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.BOOLEAN));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.CLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.DATALINK));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.DISTINCT));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.JAVA_OBJECT));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.NCLOB));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.NULL));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.OTHER));
-        Assert.assertFalse(LintUtils.isSqlTypeDateBased(Types.SQLXML));
-    }
-    
 }

--- a/src/test/resources/LinterBlobTypeColumn/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterBlobTypeColumn/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterBooleanContent/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterBooleanContent/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterByteaTypeColumn/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterByteaTypeColumn/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterColumnContentNotNormalized/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterColumnContentNotNormalized/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterColumnSize/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterColumnSize/schemacrawler-linter-configs-test.xml
@@ -219,4 +219,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterCompressBlob/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterCompressBlob/schemacrawler-linter-configs-test.xml
@@ -215,4 +215,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterForeignKeyMismatchLazy/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterForeignKeyMismatchLazy/schemacrawler-linter-configs-test.xml
@@ -219,4 +219,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterForeignKeyName/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterForeignKeyName/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterJsonContent/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterJsonContent/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterJsonTypeColumn/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterJsonTypeColumn/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterLeftSpacePadding/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterLeftSpacePadding/schemacrawler-linter-configs-test.xml
@@ -229,4 +229,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterNoSpaceInNames/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterNoSpaceInNames/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterOrphanTable/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterOrphanTable/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterPluralTableName/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterPluralTableName/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterPrimaryKeyNotIntegerLikeType/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterPrimaryKeyNotIntegerLikeType/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterRightSpacePadding/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterRightSpacePadding/schemacrawler-linter-configs-test.xml
@@ -228,4 +228,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterTableNameNotInLowerCase/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterTableNameNotInLowerCase/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>

--- a/src/test/resources/LinterTimeStampWithOutTimeZoneColumn/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterTimeStampWithOutTimeZoneColumn/schemacrawler-linter-configs-test.xml
@@ -1,0 +1,246 @@
+<!-- #%L Additional SchemaCrawler Lints %% Copyright (C) 2015 - 2016 github 
+	%% This program is free software: you can redistribute it and/or modify it 
+	under the terms of the GNU General Public License as published by the Free 
+	Software Foundation, either version 3 of the License, or (at your option) 
+	any later version. This program is distributed in the hope that it will be 
+	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+	or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for 
+	more details. You should have received a copy of the GNU General Public License 
+	along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.html>. 
+	#L% -->
+<schemacrawler-linter-configs>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>true</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterForbiddenPrimaryKeyType">
+		<run>false</run>
+		<severity>high</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterCatalogSql">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+		<config>
+			<property name="message">message for SQL catalog lint</property>
+			<property name="sql"><![CDATA[SELECT TOP 1 1 FROM INFORMATION_SCHEMA.TABLES]]></property>
+		</config>
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterColumnTypes">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterForeignKeyMismatch">
+		<run>false</run><!-- user custom linter with java sql type -->
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="schemacrawler.tools.linter.LinterForeignKeyWithNoIndexes">
+		<run>false</run>
+		<severity>medium</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterNullColumnsInIndex">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="schemacrawler.tools.linter.LinterNullIntendedColumns">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterRedundantIndexes">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="schemacrawler.tools.linter.LinterTableAllNullableColumns">
+		<run>false</run>
+		<severity>high</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterTableCycles">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterTableEmpty">
+		<run>false</run>
+		<severity>high</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterTableSql">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+		<config>
+			<property name="message">message for custom SQL lint</property>
+			<property name="sql"><![CDATA[SELECT TOP 1 1 FROM ${table}]]></property>
+		</config>
+	</linter>
+	<linter
+		id="schemacrawler.tools.linter.LinterTableWithBadlyNamedColumns">
+		<run>false</run><!-- a activer lorsqu'on aura une liste de noms -->
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="schemacrawler.tools.linter.LinterTableWithIncrementingColumns">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterTableWithNoIndexes">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="schemacrawler.tools.linter.LinterTableWithNoPrimaryKey">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+		<threshold>1</threshold>
+	</linter>
+	<linter
+		id="schemacrawler.tools.linter.LinterTableWithPrimaryKeyNotFirst">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterTableWithNoRemarks">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="schemacrawler.tools.linter.LinterTableWithQuotedNames">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+		<column-exclusion-pattern><![CDATA[\w*\.\w*\."version"]]></column-exclusion-pattern>
+	</linter>
+	<linter
+		id="schemacrawler.tools.linter.LinterTableWithSingleColumn">
+	</linter>
+	<linter id="schemacrawler.tools.linter.LinterTooManyLobs">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="schemacrawler.tools.linter.LinterUselessSurrogateKey">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTableNameNotInLowerCase">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterColumnContentNotNormalized">
+		<run>false</run>
+		<severity>high</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+		<config>
+			<property name="nbRepeatTolerance">2</property>
+			<property name="minTextColumnSize">2</property>
+		</config>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterJsonTypeColumn">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterJsonContent">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+		<config>
+			<property name="sampleSize">1000</property>
+		</config>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterXmlContent">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+		<config>
+			<property name="sampleSize">1000</property>
+		</config>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterBooleanContent">
+		<run>false</run>
+		<severity>high</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterPrimaryKeyNotIntegerLikeType">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterBlobTypeColumn">
+		<run>false</run>
+		<severity>high</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterColumnSize">
+		<run>false</run>
+		<severity>high</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+		<!-- <threshold>10</threshold> -->
+		<config>
+			<property name="minColumnSizePercent">20</property>
+		</config>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterForeignKeyMismatchLazy">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+		<threshold>1</threshold>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterForeignKeyName">
+		<run>false</run>
+		<severity>medium</severity>
+		<table-exclusion-pattern><![CDATA[.*databasechangelog*]]></table-exclusion-pattern>
+		<config>
+			<property name="foreignKeySuffix">_id</property>
+		</config>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterByteaTypeColumn">
+		<run>false</run>
+		<severity>medium</severity>
+		<table-exclusion-pattern><![CDATA[.*databasechangelog*]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterCompressBlob">
+		<run>false</run>
+		<severity>medium</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterCompressBlob">
+		<run>false</run>
+		<severity>high</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+		<config>
+			<property name="minCompressionPercent">30</property>
+		</config>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterOrphanTable">
+		<run>false</run>
+		<severity>high</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterNoSpaceInNames">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+	<linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterPluralTableName">
+		<run>false</run>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
+</schemacrawler-linter-configs>

--- a/src/test/resources/LinterXmlContent/schemacrawler-linter-configs-test.xml
+++ b/src/test/resources/LinterXmlContent/schemacrawler-linter-configs-test.xml
@@ -220,4 +220,10 @@
         <run>false</run>
         <table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
     </linter>
+    <linter
+		id="io.github.mbarre.schemacrawler.tool.linter.LinterTimeStampWithOutTimeZoneColumn">
+		<run>false</run>
+		<severity>critical</severity>
+		<table-exclusion-pattern><![CDATA[\w*\.((databasechangeloglock)|(databasechangelog))]]></table-exclusion-pattern>
+	</linter>
 </schemacrawler-linter-configs>


### PR DESCRIPTION
**[Enhancement] :** 

**Description**

Postgres supports different Date types but it's is a pain for DBA when migrating data to different databases when they come across timestamp type column without timezone.

This lint will focus on finding columns which are timestamp type and error out saying `Timestamp without time zone (timestamp) is not a permitted data type. Use timestamp with time zone (timestamptz)`

**Sample report below :** 

<img width="1008" alt="screen shot 2019-02-24 at 8 22 55 pm" src="https://user-images.githubusercontent.com/3464623/53345954-a5132780-38db-11e9-9df0-3cd8a275c2f3.png">

**Risk**: None.

**Enabled**: Yes

**Severity**: Critical 

**Story**: https://github.com/mbarre/schemacrawler-additional-lints/issues/179

**Additional Changes** : Removing Unused variables and Organizing Imports 