### PR TITLE
Checking the columnDatatype directly

### DIFF
--- a/src/main/java/io/github/mbarre/schemacrawler/tool/linter/LinterTimeStampWithOutTimeZoneColumn.java
+++ b/src/main/java/io/github/mbarre/schemacrawler/tool/linter/LinterTimeStampWithOutTimeZoneColumn.java
@@ -86,7 +86,7 @@ public class LinterTimeStampWithOutTimeZoneColumn extends BaseLinter {
 		List<Column> columns = getColumns(table);
 		for (Column column : columns) {
 			LOGGER.log(Level.INFO, "Checking {0}...", column.getFullName());
-			if (LintUtils.isSqlTypeTimeStampBased(column.getColumnDataType().getJavaSqlType().getVendorTypeNumber())) {
+			if (column.getColumnDataType().toString().equalsIgnoreCase("timestamp")) {
 				addLint(table, getDescription(), column.getFullName());
 			}
 		}

--- a/src/test/db/liquibase/LinterTimeStampWithOutTimeZoneColumn/db.changelog.xml
+++ b/src/test/db/liquibase/LinterTimeStampWithOutTimeZoneColumn/db.changelog.xml
@@ -31,6 +31,7 @@
 			<column name="id" 				type="int" 			remarks="primary key"/>
 			<column name="content"                          type="varchar(20)"/>
 			<column name="created_at"                          type="timestamp" remarks="column timestamp type"/>
+			<column name="updated_at"                          type="timestamptz" remarks="column timestamp type"/>
 		</createTable>
 
 		<addPrimaryKey columnNames="id"
@@ -38,7 +39,7 @@
 					   schemaName="public"
 					   tableName="test_timetsamp_type"/>
 
-		<sql>insert into test_timetsamp_type(id, content, created_at) values (1, 'timestamp_lint', current_timestamp)</sql>
+		<sql>insert into test_timetsamp_type(id, content, created_at,updated_at) values (1, 'timestamp_lint', current_timestamp,current_timestamp::timestamptz)</sql>
 
 	</changeSet>
 


### PR DESCRIPTION
**Fixes** : https://github.com/mbarre/schemacrawler-additional-lints/issues/190

**Description** : Currently  PostgreSQL JDBC driver is returning same data type for TimeStamp and TimeStampTimeZone as per details mentioned on https://github.com/schemacrawler/SchemaCrawler/issues/246 , so directly referring to ColumnDataType. This is the work around for now.

**Risk** : NONE 
**Tested** : Yes

**Timeline** : when ever